### PR TITLE
Add user management page for admin

### DIFF
--- a/REA/ViewModels/LoginViewModel.cs
+++ b/REA/ViewModels/LoginViewModel.cs
@@ -3,7 +3,6 @@ using System.Windows.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using REA.Utils;
-using REA.Views;
 
 namespace REA.ViewModels {
     public partial class LoginViewModel : ObservableObject {

--- a/REA/Views/AdministratorPage.xaml
+++ b/REA/Views/AdministratorPage.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="REA.Views.AdministratorPage"
              Title="Administrator Page">
+    
     <VerticalStackLayout>
         <Label 
             Text="Welcome Adminstrator"
@@ -10,7 +11,7 @@
             HorizontalOptions="Center" FontSize="24" Margin="25" />
         
         <Button Text="Update Sensor Config" Margin="40"></Button>
-        <Button Text="Button 2" Margin="40"></Button>
+        <Button Text="Manage User Access" Margin="40" Clicked="OnManageUserAccessClicked"></Button>
         <Button Text="Back Dashboard" Margin="40"></Button>
 
         <Label Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. In facilisis nulla eu felis fringilla vulputate. Nullam porta eleifend lacinia. Donec at iaculis tellus."

--- a/REA/Views/AdministratorPage.xaml.cs
+++ b/REA/Views/AdministratorPage.xaml.cs
@@ -6,4 +6,8 @@ public partial class AdministratorPage : ContentPage
 	{
 		InitializeComponent();
 	}
+
+    private async void OnManageUserAccessClicked(object sender, EventArgs e) {
+        await Navigation.PushAsync(new UserManagementPage());
+    }
 }

--- a/REA/Views/UserManagementPage.xaml
+++ b/REA/Views/UserManagementPage.xaml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="REA.Views.UserManagementPage"
+             Title="User Management">
+
+    <VerticalStackLayout Padding="20">
+        <Label Text="Select a User:" FontSize="20"/>
+
+        <ListView x:Name="UsersListView" SelectionMode="Single" ItemSelected="OnUserSelected">
+            <ListView.ItemTemplate>
+                <DataTemplate>
+                    <TextCell Text="{Binding Name}" Detail="{Binding Role}"/>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+
+        <Label Text="Assign Role:" FontSize="20" Margin="0,20,0,0"/>
+        <Picker x:Name="RolesPicker" Title="Select a Role" SelectedIndexChanged="OnRoleSelected"/>
+
+        <Button Text="Save Changes" Clicked="OnSaveClicked" IsEnabled="False" x:Name="SaveButton" Margin="0,30,0,0"/>
+    </VerticalStackLayout>
+</ContentPage>

--- a/REA/Views/UserManagementPage.xaml.cs
+++ b/REA/Views/UserManagementPage.xaml.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Maui.Controls;
+
+namespace REA.Views {
+    public partial class UserManagementPage : ContentPage {
+        // Dummy users
+        private List<User> users;
+        // Dummy roles
+        private List<string> roles;
+        // Current selected user
+        private User selectedUser;
+
+        public UserManagementPage() {
+            InitializeComponent();
+            LoadDummyData();
+        }
+
+        private void LoadDummyData() {
+            users = new List<User> {
+                new User { Id = 1, Name = "John Smith", Role = "User" },
+                new User { Id = 2, Name = "Bruce Lee", Role = "Admin" },
+                new User { Id = 3, Name = "Bob Ross ", Role = "Moderator" }
+            };
+
+            roles = new List<string> { "User", "Admin", "Moderator" };
+
+            UsersListView.ItemsSource = users;
+            RolesPicker.ItemsSource = roles;
+        }
+
+        private void OnUserSelected(object sender, SelectedItemChangedEventArgs e) {
+            selectedUser = (User)e.SelectedItem;
+            if (selectedUser != null) {
+                RolesPicker.SelectedItem = selectedUser.Role;
+                SaveButton.IsEnabled = true; 
+            }
+        }
+
+        private void OnRoleSelected(object sender, EventArgs e) {
+            if (selectedUser != null) {
+                selectedUser.Role = RolesPicker.SelectedItem?.ToString();
+            }
+        }
+
+        private void OnSaveClicked(object sender, EventArgs e) {
+            if (selectedUser != null) {
+                DisplayAlert("Success", $"{selectedUser.Name} is now a {selectedUser.Role}.", "OK");
+            } else {
+                DisplayAlert("Error", "Please select a user first.", "OK");
+            }
+        }
+    }
+
+
+    // Dummy User object for prototyping purposes
+    public class User {
+        public int Id { get; set; }
+        public required string Name { get; set; }
+        public required string Role { get; set; }
+    }
+}


### PR DESCRIPTION
Added a basic page for admins to update user roles (frontend only with dummy data) #11 

### Changes
- Adjusted the Admin panel by changing the placeholder "Button 2" with "Manage User Access". 
- Created `UserManagementPage`, which lists dummy users and allows to set a role to a selected user.

> [!NOTE]  
> It contains front-end design only with dummy data and will be populated with database data in future sprint(s).