### PR TITLE
Feature/historical data

### DIFF
--- a/REA/AppShell.xaml.cs
+++ b/REA/AppShell.xaml.cs
@@ -12,6 +12,7 @@ namespace REA {
             Routing.RegisterRoute("UpdateSensor", typeof(UpdateSensorPage));
             Routing.RegisterRoute("EnvironmentalReports", typeof(GenerateReportsPage));
             Routing.RegisterRoute("SensorMalfunctions", typeof(ReportMalfunctioningSensorsPage));
+            Routing.RegisterRoute("HistoricalData", typeof(HistoricalDataPage));
 
             BindingContext = new AppShellViewModel();
 

--- a/REA/REA.csproj
+++ b/REA/REA.csproj
@@ -79,6 +79,9 @@
 	  <MauiXaml Update="Views\GenerateReportsPage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
+	  <MauiXaml Update="Views\HistoricalDataPage.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
 	  <MauiXaml Update="Views\LoginPage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>

--- a/REA/ViewModels/EnvironmentalScientistViewModel.cs
+++ b/REA/ViewModels/EnvironmentalScientistViewModel.cs
@@ -7,11 +7,14 @@ public class EnvironmentalScientistViewModel : ObservableObject
 {
 	public ICommand NavigateToDashboardCommand { get; }
     public ICommand NavigateToReportsCommand {  get; }
+    public ICommand NavigateToHistoricalDataCommand {  get; }
 
-	public EnvironmentalScientistViewModel()
+
+    public EnvironmentalScientistViewModel()
 	{
         NavigateToDashboardCommand = new Command(async () => await NavigateToDashboard());
         NavigateToReportsCommand = new Command(async () => await NavigateToReports());
+        NavigateToHistoricalDataCommand = new Command(async () => await NavigateToHistoricalData());
 
     }
     private async Task NavigateToDashboard()
@@ -21,5 +24,9 @@ public class EnvironmentalScientistViewModel : ObservableObject
     private async Task NavigateToReports()
     {
         await Shell.Current.GoToAsync("EnvironmentalReports");
+    }
+
+    private async Task NavigateToHistoricalData() {
+        await Shell.Current.GoToAsync("HistoricalData");
     }
 }

--- a/REA/ViewModels/HistoricalDataViewModel.cs
+++ b/REA/ViewModels/HistoricalDataViewModel.cs
@@ -33,6 +33,8 @@ namespace REA.ViewModels
 
         public HistoricalDataViewModel() {
             SelectCategoryCommand = new RelayCommand<string>(SelectCategory);
+
+            // Load dummy data for testing purposes
             LoadDummyData();
         }
 
@@ -67,7 +69,9 @@ namespace REA.ViewModels
     }
 
 
-    // Dummy objecst for prototyping until database is implemented
+    //////// Dummy objects for prototyping until database is implemented ////////
+
+    // Air Quality 
     public class AirQualityData {
         public DateTime Date { get; set; }
         public double NitrogenDioxide { get; set; }
@@ -76,6 +80,7 @@ namespace REA.ViewModels
         public double PM10 { get; set; }
     }
 
+    // Water Quality
     public class WaterQualityData {
         public DateTime Date { get; set; }
         public double Nitrate { get; set; }
@@ -84,6 +89,7 @@ namespace REA.ViewModels
         public double EC { get; set; }
     }
 
+    // Weather Data
     public class WeatherData {
         public DateTime Date { get; set; }
         public double Temperature { get; set; }

--- a/REA/ViewModels/HistoricalDataViewModel.cs
+++ b/REA/ViewModels/HistoricalDataViewModel.cs
@@ -1,0 +1,94 @@
+﻿using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace REA.ViewModels
+{
+    public partial class HistoricalDataViewModel : ObservableObject {
+
+        // Data categories
+        [ObservableProperty]
+        private ObservableCollection<AirQualityData> airQualityRecords;
+
+        [ObservableProperty]
+        private ObservableCollection<WaterQualityData> waterQualityRecords;
+
+        [ObservableProperty]
+        private ObservableCollection<WeatherData> weatherRecords;
+
+        // Control visibility of categories
+        [ObservableProperty]
+        private bool isAirQualityVisible;
+
+        [ObservableProperty]
+        private bool isWaterQualityVisible;
+
+        [ObservableProperty]
+        private bool isWeatherVisible;
+
+
+        // Switching categories
+        public IRelayCommand SelectCategoryCommand { get; }
+
+
+        public HistoricalDataViewModel() {
+            SelectCategoryCommand = new RelayCommand<string>(SelectCategory);
+            LoadDummyData();
+        }
+
+        private void LoadDummyData() {
+            AirQualityRecords = new ObservableCollection<AirQualityData>
+            {
+                new AirQualityData { Date = DateTime.Now.AddDays(-1), NitrogenDioxide = 30, SulphurDioxide = 20, PM25 = 12, PM10 = 25 },
+                new AirQualityData { Date = DateTime.Now.AddDays(-2), NitrogenDioxide = 28, SulphurDioxide = 18, PM25 = 14, PM10 = 22 }
+            };
+
+            WaterQualityRecords = new ObservableCollection<WaterQualityData>
+            {
+                new WaterQualityData { Date = DateTime.Now.AddDays(-1), Nitrate = 5.2, Nitrite = 0.8, Phosphate = 1.3, EC = 450 },
+                new WaterQualityData { Date = DateTime.Now.AddDays(-2), Nitrate = 5.5, Nitrite = 0.7, Phosphate = 1.5, EC = 460 }
+            };
+
+            WeatherRecords = new ObservableCollection<WeatherData>
+            {
+                new WeatherData { Date = DateTime.Now.AddDays(-1), Temperature = 22.5, RelativeHumidity = 60, WindSpeed = 15, WindDirection = "N" },
+                new WeatherData { Date = DateTime.Now.AddDays(-2), Temperature = 21.0, RelativeHumidity = 58, WindSpeed = 10, WindDirection = "NE" }
+            };
+        }
+
+        // Category selection
+        private void SelectCategory(string category) {
+            IsAirQualityVisible = category == "AirQuality";
+            IsWaterQualityVisible = category == "WaterQuality";
+            IsWeatherVisible = category == "Weather";
+        }
+
+
+    }
+
+
+    // Dummy objecst for prototyping until database is implemented
+    public class AirQualityData {
+        public DateTime Date { get; set; }
+        public double NitrogenDioxide { get; set; }
+        public double SulphurDioxide { get; set; }
+        public double PM25 { get; set; }
+        public double PM10 { get; set; }
+    }
+
+    public class WaterQualityData {
+        public DateTime Date { get; set; }
+        public double Nitrate { get; set; }
+        public double Nitrite { get; set; }
+        public double Phosphate { get; set; }
+        public double EC { get; set; }
+    }
+
+    public class WeatherData {
+        public DateTime Date { get; set; }
+        public double Temperature { get; set; }
+        public double RelativeHumidity { get; set; }
+        public double WindSpeed { get; set; }
+        public string WindDirection { get; set; }
+    }
+}

--- a/REA/Views/EnvironmentalScientistPage.xaml
+++ b/REA/Views/EnvironmentalScientistPage.xaml
@@ -19,7 +19,7 @@
             HorizontalOptions="Center" FontSize="24" Margin="25" />
 
             <Button Text="Generate Reports" Command="{Binding NavigateToReportsCommand}" Margin="10" />
-            <Button Text="Button 2" Margin="10"></Button>
+            <Button Text="Historical Data" Command="{Binding NavigateToHistoricalDataCommand}" Margin="10" />
             <Button Text="Back Dashboard" Command="{Binding NavigateToDashboardCommand}" Margin="10" />
 
             <Border Margin="10">

--- a/REA/Views/HistoricalDataPage.xaml
+++ b/REA/Views/HistoricalDataPage.xaml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="REA.Views.HistoricalDataPage"
+             xmlns:vm="clr-namespace:REA.ViewModels"
+             Title="Historical Data">
+    <ContentPage.BindingContext>
+        <vm:HistoricalDataViewModel />
+    </ContentPage.BindingContext>
+
+    <StackLayout Padding="10">
+        <Label Text="Historical Environmental Data" FontSize="Large" HorizontalOptions="Center" />
+
+        <!-- Tabs for selecting category -->
+        <StackLayout Orientation="Horizontal" Spacing="10" HorizontalOptions="Center">
+            <Button Text="Air Quality" Command="{Binding SelectCategoryCommand}" CommandParameter="AirQuality" />
+            <Button Text="Water Quality" Command="{Binding SelectCategoryCommand}" CommandParameter="WaterQuality" />
+            <Button Text="Weather" Command="{Binding SelectCategoryCommand}" CommandParameter="Weather" />
+        </StackLayout>
+
+        <!-- Air Quality Data Table -->
+        <CollectionView ItemsSource="{Binding AirQualityRecords}" IsVisible="{Binding IsAirQualityVisible}">
+            <CollectionView.Header>
+                <Grid Padding="10">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Label Grid.Row="0" Grid.Column="0" Text="Date" />
+                    <Label Grid.Row="0" Grid.Column="1" Text="NO₂ (µg/m³)" />
+                    <Label Grid.Row="0" Grid.Column="2" Text="SO₂ (µg/m³)" />
+                    <Label Grid.Row="0" Grid.Column="3" Text="PM2.5 (µg/m³)"/>
+                    <Label Grid.Row="0" Grid.Column="4" Text="PM10 (µg/m³)" />
+                </Grid>
+            </CollectionView.Header>
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Grid Padding="5">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <Label Grid.Row="0" Grid.Column="0" Text="{Binding Date, StringFormat='{}{0:dd/MM/yyyy}'}" />
+                        <Label Grid.Row="0" Grid.Column="1" Text="{Binding NitrogenDioxide}" />
+                        <Label Grid.Row="0" Grid.Column="2" Text="{Binding SulphurDioxide}" />
+                        <Label Grid.Row="0" Grid.Column="3" Text="{Binding PM25}" />
+                        <Label Grid.Row="0" Grid.Column="4" Text="{Binding PM10}" />
+                    </Grid>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+
+        <!-- Water Quality Data Table -->
+        <CollectionView ItemsSource="{Binding WaterQualityRecords}" IsVisible="{Binding IsWaterQualityVisible}">
+            <CollectionView.Header>
+                <Grid Padding="10">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Label Grid.Row="0" Grid.Column="0" Text="Date" />
+                    <Label Grid.Row="0" Grid.Column="1" Text="Nitrate (mg/L)"/>
+                    <Label Grid.Row="0" Grid.Column="2" Text="Nitrite (mg/L)"/>
+                    <Label Grid.Row="0" Grid.Column="3" Text="Phosphate (mg/L)"/>
+                    <Label Grid.Row="0" Grid.Column="4" Text="EC (µS/cm)"/>
+                </Grid>
+            </CollectionView.Header>
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Grid Padding="5">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <Label Grid.Row="0" Grid.Column="0" Text="{Binding Date, StringFormat='{}{0:dd/MM/yyyy}'}" />
+                        <Label Grid.Row="0" Grid.Column="1" Text="{Binding Nitrate}" />
+                        <Label Grid.Row="0" Grid.Column="2" Text="{Binding Nitrite}" />
+                        <Label Grid.Row="0" Grid.Column="3" Text="{Binding Phosphate}" />
+                        <Label Grid.Row="0" Grid.Column="4" Text="{Binding EC}" />
+                    </Grid>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+
+        <!-- Weather Data Table -->
+        <CollectionView ItemsSource="{Binding WeatherRecords}" IsVisible="{Binding IsWeatherVisible}">
+            <CollectionView.Header>
+                <Grid Padding="10">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Label Grid.Row="0" Grid.Column="0" Text="Date"/>
+                    <Label Grid.Row="0" Grid.Column="1" Text="Temperature (°C)"/>
+                    <Label Grid.Row="0" Grid.Column="2" Text="Humidity (%)"/>
+                    <Label Grid.Row="0" Grid.Column="3" Text="Wind Speed (km/h)"/>
+                    <Label Grid.Row="0" Grid.Column="4" Text="Wind Direction"/>
+                </Grid>
+            </CollectionView.Header>
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Grid Padding="5">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <Label Grid.Row="0" Grid.Column="0" Text="{Binding Date, StringFormat='{}{0:dd/MM/yyyy}'}" />
+                        <Label Grid.Row="0" Grid.Column="1" Text="{Binding Temperature}" />
+                        <Label Grid.Row="0" Grid.Column="2" Text="{Binding RelativeHumidity}" />
+                        <Label Grid.Row="0" Grid.Column="3" Text="{Binding WindSpeed}" />
+                        <Label Grid.Row="0" Grid.Column="4" Text="{Binding WindDirection}" />
+                    </Grid>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+
+    </StackLayout>
+</ContentPage>

--- a/REA/Views/HistoricalDataPage.xaml.cs
+++ b/REA/Views/HistoricalDataPage.xaml.cs
@@ -1,0 +1,9 @@
+namespace REA.Views;
+
+public partial class HistoricalDataPage : ContentPage
+{
+	public HistoricalDataPage()
+	{
+		InitializeComponent();
+	}
+}


### PR DESCRIPTION
Added `HistoricalData` page for the EnvironmentalScientist role, which allows the user to view the historical data for the three different categories: weather data, water quality, and air quality.

The third part of the #25 task, which adds the frontend code for the page.

> [!NOTE]
> The code has dummy objects to simulate actual data until the database is implemented.