### PR TITLE
Add db integration to monitor sensors page

### DIFF
--- a/REA/ViewModels/MonitorSensorsViewModel.cs
+++ b/REA/ViewModels/MonitorSensorsViewModel.cs
@@ -26,7 +26,6 @@ namespace REA.ViewModels {
         private async void GetSensors() {
             // Get all sensors from database
             Sensors = new ObservableCollection<Sensors>(await SQLiteDatabaseService.Instance.GetItemsAsync<Sensors>());
-            var items = new ObservableCollection<Sensors>(await SQLiteDatabaseService.Instance.GetItemsAsync<Sensors>());
         }
 
         // Set the selected sensor

--- a/REA/ViewModels/MonitorSensorsViewModel.cs
+++ b/REA/ViewModels/MonitorSensorsViewModel.cs
@@ -1,27 +1,37 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+﻿using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using REA.DB;
 using REA.Models;
-using System.Collections.ObjectModel;
 
 namespace REA.ViewModels {
+    /// <summary>
+    /// ViewModel responsible for backend for displaying all sensors and their details.
+    /// Author: Nikita Lanetsky
+    /// </summary>
     public partial class MonitorSensorsViewModel : ObservableObject {
 
+        // Selected sensor (if any)
         [ObservableProperty]
-        private Sensor selectedSensor;
+        private Sensors selectedSensor;
 
-        public ObservableCollection<Sensor> Sensors { get; set; }
+        // List of available sensors
+        [ObservableProperty]
+        private ObservableCollection<Sensors> sensors;
 
         public MonitorSensorsViewModel() {
-            Sensors = new ObservableCollection<Sensor>
-            {
-                new Sensor { Id = 1, SensorType = "Temperature", SensorUrl = "http://temp-sensor.com", DeploymentDate = DateTime.Now.AddDays(-10), IsOperational = true },
-                new Sensor { Id = 2, SensorType = "Pressure", SensorUrl = "http://pressure-sensor.com", DeploymentDate = DateTime.Now.AddDays(-20), IsOperational = false },
-                new Sensor { Id = 3, SensorType = "Humidity", SensorUrl = "http://humidity-sensor.com", DeploymentDate = DateTime.Now.AddDays(-30), IsOperational = true }
-            };
+            GetSensors();
         }
 
+        private async void GetSensors() {
+            // Get all sensors from database
+            Sensors = new ObservableCollection<Sensors>(await SQLiteDatabaseService.Instance.GetItemsAsync<Sensors>());
+            var items = new ObservableCollection<Sensors>(await SQLiteDatabaseService.Instance.GetItemsAsync<Sensors>());
+        }
+
+        // Set the selected sensor
         [RelayCommand]
-        private void SelectSensor(Sensor sensor) {
+        private void SelectSensor(Sensors sensor) {
             SelectedSensor = sensor;
         }
     }

--- a/REA/Views/MonitorSensorsPage.xaml
+++ b/REA/Views/MonitorSensorsPage.xaml
@@ -9,32 +9,36 @@
         <vm:MonitorSensorsViewModel />
     </ContentPage.BindingContext>
 
-    <VerticalStackLayout Padding="20">
-        <Label Text="Available Sensors" FontAttributes="Bold" Margin="0, 0, 10, 0"/>
+    <VerticalStackLayout Padding="10" Spacing="10">
+
+        <Label Text="Available Sensors" FontAttributes="Bold" />
+        <!--Listview of available sensors-->
         <ListView ItemsSource="{Binding Sensors}"
-                  SelectedItem="{Binding SelectedSensor, Mode=TwoWay}">
+                  SelectedItem="{Binding SelectedSensor, Mode=TwoWay}"
+                  HeightRequest="250">
             <ListView.ItemTemplate>
                 <DataTemplate>
-                    <TextCell  Text="{Binding SensorType}" Detail="{Binding SensorUrl}">
-                        <TextCell.Command>
-                            <Binding Path="BindingContext.SelectSensorCommand" Source="{x:Reference MonitorSensorsPage}" />
-                        </TextCell.Command>
-                        <TextCell.CommandParameter>
-                            <Binding />
-                        </TextCell.CommandParameter>
-                    </TextCell>
+                    <ViewCell>
+                        <StackLayout Padding="5">
+                            <!--Each sensor - display id and type-->
+                            <Label Text="{Binding SensorId, StringFormat='Sensor ID: {0}'}" />
+                            <Label Text="{Binding SensorType, StringFormat='Sensor Type: {0}'}" />
+                        </StackLayout>
+                    </ViewCell>
                 </DataTemplate>
             </ListView.ItemTemplate>
         </ListView>
 
-        <Border Margin="10, 0">
-            <StackLayout>
-                <Label Text="Sensor Details" FontAttributes="Bold" Margin="0, 0, 10, 0"/>
-                <Label Text="{Binding SelectedSensor.SensorType, StringFormat='Type: {0}'}" Margin="0, 10"/>
-                <Label Text="{Binding SelectedSensor.SensorUrl, StringFormat='URL: {0}'}" Margin="0, 10"/>
-                <Label Text="{Binding SelectedSensor.DeploymentDate, StringFormat='Deployed: {0:d}'}" Margin="0, 10"/>
-                <Label Text="{Binding SelectedSensor.IsOperational, StringFormat='Operational: {0}'}" Margin="0, 10"/>
-            </StackLayout>
-        </Border>
+
+        <BoxView HeightRequest="1" Color="Gray" />
+
+        <Label Text="Sensor Details" FontAttributes="Bold" />
+        <!--Selected sensor details-->
+        <Label Text="{Binding SelectedSensor.SensorId, StringFormat='ID: {0}'}" />
+        <Label Text="{Binding SelectedSensor.SensorType, StringFormat='Type: {0}'}" />
+        <Label Text="{Binding SelectedSensor.SensorUrl, StringFormat='URL: {0}'}" />
+        <Label Text="{Binding SelectedSensor.DeploymentDate, StringFormat='Deployed: {0:d}'}" />
+        <Label Text="{Binding SelectedSensor.SensorOperational, StringFormat='Operational: {0}'}" />
+
     </VerticalStackLayout>
 </ContentPage>


### PR DESCRIPTION
Improved the `monitor-sensors` page by integrating the database records and removing the dummy data.

### Changes
- Removed dummy data.
- Added DB integration: reads all sensor records from the database.

> [!IMPORTANT]
> This is a small feature as the majority of the `monitor-sensors` was previously implemented (frontend and dummy data) and was postponed until the `Sensors` model was implemented (`Sensors` model was implemented in #58). 