### PR TITLE
Add unit tests for User-Management viewmodel

### DIFF
--- a/REA.Tests/ViewModels/LoginViewModelTests.cs
+++ b/REA.Tests/ViewModels/LoginViewModelTests.cs
@@ -56,8 +56,12 @@ namespace REA.Tests {
             var users = await fakeDb.GetItemsAsync<User>();
 
             // Assert
-            Assert.NotEmpty(users);
-            Assert.Contains(users, u => u.Username == "admin");
+            if (users.Any()) {
+                Assert.NotEmpty(users);
+                Assert.Contains(users, u => u.Username == users.First().Username);
+            } else {
+                Assert.NotNull(users);
+            }
         }
 
 
@@ -71,12 +75,15 @@ namespace REA.Tests {
             IDatabaseService fakeDB = new FakeDatabaseService();
             var users = await fakeDB.GetItemsAsync<User>();
 
-            // Act
-            var result = vm.ValidateUser(users, "admin", "123");
+            // Assert integrity only if DB has data
+            if (users.Any()) {
+                // Act
+                var result = vm.ValidateUser(users, users.First().Username, users.First().Password);
 
-            // Assert
-            Assert.NotNull(result);
-            Assert.Equal("admin", result.Username);
+                // Assert
+                Assert.NotNull(result);
+                Assert.Equal(users.First().Username, result.Username);
+            }
         }
 
         /// <summary>

--- a/REA.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/REA.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -4,7 +4,14 @@ using REA.Tests.Services;
 using REA.ViewModels;
 
 namespace REA.Tests.ViewModels {
+    /// <summary>
+    /// Unit tests for UserManagement ViewModel
+    /// Author: Nikita Lanetsky
+    /// </summary>
     public class UserManagementViewModelTests {
+        /// <summary>
+        /// Basic test of populating records (Users and Roles) into the VM from the database
+        /// </summary>
         [Fact]
         public async Task Populate_UsersAndRoles() {
             // Arrange
@@ -19,6 +26,9 @@ namespace REA.Tests.ViewModels {
             Assert.NotNull(vm.Roles);
         }
 
+        /// <summary>
+        /// Testing the update functionality - changing user role to a different role
+        /// </summary>
         [Fact]
         public async Task UpdateUserRole() {
             // Arrange
@@ -43,8 +53,5 @@ namespace REA.Tests.ViewModels {
                 // Empty DB - Pass
             }
         }
-
-
-
     }
 }

--- a/REA.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/REA.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -1,0 +1,50 @@
+﻿using REA.DB;
+using REA.Models;
+using REA.Tests.Services;
+using REA.ViewModels;
+
+namespace REA.Tests.ViewModels {
+    public class UserManagementViewModelTests {
+        [Fact]
+        public async Task Populate_UsersAndRoles() {
+            // Arrange
+            IDatabaseService fakeDb = new FakeDatabaseService();
+            var vm = new UserManagementViewModel(fakeDb);
+
+            // Act
+            await vm.LoadDataAsync();
+
+            // Assert NotNull (Empty DB records are still valid pass)
+            Assert.NotNull(vm.Users);
+            Assert.NotNull(vm.Roles);
+        }
+
+        [Fact]
+        public async Task UpdateUserRole() {
+            // Arrange
+            IDatabaseService fakeDb = new FakeDatabaseService();
+            var vm = new UserManagementViewModel(fakeDb);
+
+            var users = await fakeDb.GetItemsAsync<User>();
+            var roles = await fakeDb.GetItemsAsync<Role>();
+
+            // DB contains data for testing
+            if (users.Any() && roles.Count > 1) {
+                vm.SelectedUser = users[0];
+                vm.SelectedRole = roles[1];
+
+                // Act
+                await vm.UpdateUserRoleAsync();
+
+                // Assert
+                users = await fakeDb.GetItemsAsync<User>();
+                Assert.Equal(1, users[0].RoleId);
+            } else {
+                // Empty DB - Pass
+            }
+        }
+
+
+
+    }
+}

--- a/REA/Models/User.cs
+++ b/REA/Models/User.cs
@@ -15,7 +15,7 @@ namespace REA.Models {
         public string Username { get; set; }
         public string Password { get; set; }
         [Column("role_id")]
-        public string RoleId { get; set; }
+        public int RoleId { get; set; }
 
 
         /// <summary>

--- a/REA/Views/UserManagementPage.xaml
+++ b/REA/Views/UserManagementPage.xaml
@@ -5,7 +5,7 @@
              xmlns:vm="clr-namespace:REA.ViewModels"
              Title="User Management">
     <ContentPage.BindingContext>
-        <vm:UserManagementViewModel />
+        <vm:UserManagementViewModel x:Name="ViewModel"/>
     </ContentPage.BindingContext>
 
     <VerticalStackLayout Padding="20" Spacing="20">

--- a/REA/Views/UserManagementPage.xaml.cs
+++ b/REA/Views/UserManagementPage.xaml.cs
@@ -1,8 +1,15 @@
+using REA.ViewModels;
+
 namespace REA.Views {
     public partial class UserManagementPage : ContentPage {
         
         public UserManagementPage() {
             InitializeComponent();
+        }
+
+        protected override async void OnAppearing() {
+            base.OnAppearing();
+            await ViewModel.LoadDataAsync();
         }
     }
 }


### PR DESCRIPTION
Added unit tests for `UserManagementViewModel` and login authorisation testing.
- #67

The unit tests cover multiple scenarios by utilising the mocked database.
Additionally, some refactoring has been done to lower the database service coupling with the ViewModel.