### PR TITLE
Add unit tests for historical-data viewmodel

### DIFF
--- a/REA.Tests/ViewModels/HistoricalDataViewModelTests.cs
+++ b/REA.Tests/ViewModels/HistoricalDataViewModelTests.cs
@@ -1,0 +1,48 @@
+﻿using REA.DB;
+using REA.Models;
+using REA.Tests.Services;
+using REA.ViewModels;
+
+namespace REA.Tests.ViewModels {
+    /// <summary>
+    /// Unit tests for HistoricalData ViewModel
+    /// Author: Nikita Lanetsky
+    /// </summary>
+    public class HistoricalDataViewModelTests {
+
+        /// <summary>
+        /// Tests the population of records in the VM and compares with the actual database data (if any)
+        /// </summary>
+        [Fact]
+        public async Task Populate_HistoricalData() {
+            // Arrange
+            IDatabaseService fakeDb = new FakeDatabaseService();
+            var vm = new HistoricalDataViewModel(fakeDb);
+
+            var airMeasurements = await fakeDb.GetItemsAsync<AirMeasurement>();
+            var waterMeasurements = await fakeDb.GetItemsAsync<WaterMeasurement>();
+            var weatherMeasurements = await fakeDb.GetItemsAsync<WeatherMeasurement>();
+
+            // Act
+            await vm.PopulateRecords();
+
+            // Assert - Air
+            Assert.Equal(airMeasurements.Count, vm.AirMeasurements.Count);
+            for (int i = 0; i < airMeasurements.Count; i++) {
+                Assert.Equal(airMeasurements[i].AirMeasurementsId, vm.AirMeasurements[i].AirMeasurementsId);
+            }
+
+            // Assert - Water
+            Assert.Equal(waterMeasurements.Count, vm.WaterMeasurements.Count);
+            for (int i = 0; i < waterMeasurements.Count; i++) {
+                Assert.Equal(waterMeasurements[i].WaterMeasurementId, vm.WaterMeasurements[i].WaterMeasurementId);
+            }
+
+            // Assert - Weather
+            Assert.Equal(weatherMeasurements.Count, vm.WeatherMeasurements.Count);
+            for (int i = 0; i < weatherMeasurements.Count; i++) {
+                Assert.Equal(weatherMeasurements[i].WeatherMeasurementsId, vm.WeatherMeasurements[i].WeatherMeasurementsId);
+            }
+        }
+    }
+}

--- a/REA/ViewModels/HistoricalDataViewModel.cs
+++ b/REA/ViewModels/HistoricalDataViewModel.cs
@@ -35,23 +35,25 @@ namespace REA.ViewModels {
         // Switching categories
         public IRelayCommand SelectCategoryCommand { get; }
 
+        // DB service
+        private readonly IDatabaseService _db;
 
-        public HistoricalDataViewModel() {
+        public HistoricalDataViewModel() : this(SQLiteDatabaseService.Instance) { }
+
+        public HistoricalDataViewModel(IDatabaseService? db = null) {
+            _db = db ?? SQLiteDatabaseService.Instance;
             SelectCategoryCommand = new RelayCommand<string>(SelectCategory);
-
-            // Populate lists
-            populateRecords();
         }
 
-        public async void populateRecords() {
+        public async Task PopulateRecords() {
             // Water
-            var water = await SQLiteDatabaseService.Instance.GetItemsAsync<WaterMeasurement>();
+            var water = await _db.GetItemsAsync<WaterMeasurement>();
             WaterMeasurements = new ObservableCollection<WaterMeasurement>(water?.ToList() ?? new List<WaterMeasurement>());
             // Air
-            var air = await SQLiteDatabaseService.Instance.GetItemsAsync<AirMeasurement>();
+            var air = await _db.GetItemsAsync<AirMeasurement>();
             AirMeasurements = new ObservableCollection<AirMeasurement>(air?.ToList() ?? new List<AirMeasurement>());
             // Weather
-            var weather = await SQLiteDatabaseService.Instance.GetItemsAsync<WeatherMeasurement>();
+            var weather = await _db.GetItemsAsync<WeatherMeasurement>();
             WeatherMeasurements = new ObservableCollection<WeatherMeasurement>(weather?.ToList() ?? new List<WeatherMeasurement>());
         }
 

--- a/REA/Views/HistoricalDataPage.xaml
+++ b/REA/Views/HistoricalDataPage.xaml
@@ -5,7 +5,7 @@
              xmlns:vm="clr-namespace:REA.ViewModels"
              Title="Historical Data">
     <ContentPage.BindingContext>
-        <vm:HistoricalDataViewModel />
+        <vm:HistoricalDataViewModel x:Name="ViewModel" />
     </ContentPage.BindingContext>
 
     <StackLayout Padding="10">

--- a/REA/Views/HistoricalDataPage.xaml.cs
+++ b/REA/Views/HistoricalDataPage.xaml.cs
@@ -6,4 +6,9 @@ public partial class HistoricalDataPage : ContentPage
 	{
 		InitializeComponent();
 	}
+
+	protected override async void OnAppearing() {
+		base.OnAppearing();
+		await ViewModel.PopulateRecords();
+    }
 }


### PR DESCRIPTION
Added unit tests for `HistoricalDataViewModel`.
- #65 

There's only one unit test which tests the retrieval of data and its integrity from the mocked database, but handles empty data scenarios as well.
Additionally, some refactoring has been done to lower the database service coupling with the ViewModel.