### PR TITLE
Add unit tests for monitor sensors viewmodel

### DIFF
--- a/REA.Tests/ViewModels/MonitorSensorsViewModelTests.cs
+++ b/REA.Tests/ViewModels/MonitorSensorsViewModelTests.cs
@@ -1,0 +1,40 @@
+﻿using REA.DB;
+using REA.Models;
+using REA.Tests.Services;
+using REA.ViewModels;
+
+namespace REA.Tests.ViewModels {
+    /// <summary>
+    /// Unit tests for MonitorSensors ViewModel
+    /// Author: Nikita Lanetsky
+    /// </summary>
+    public class MonitorSensorsViewModelTests {
+
+
+        /// <summary>
+        /// Tests the population of records in the vm and compares with the actual database data (if any)
+        /// </summary>
+        [Fact]
+        public async Task Populate_Sensors() {
+            // Arrange
+            IDatabaseService fakeDb = new FakeDatabaseService();
+            var vm = new MonitorSensorsViewModel(fakeDb);
+            var expectedSensors = await fakeDb.GetItemsAsync<Sensors>();
+
+            // Act
+            await vm.GetSensors();
+
+            // Assert NotNull (empty db records are still valid pass)
+            Assert.NotNull(vm.Sensors);
+
+            // Assert data structure
+            Assert.Equal(expectedSensors.Count, vm.Sensors.Count);
+            if (expectedSensors != null && expectedSensors.Count > 0 && expectedSensors.Count == vm.Sensors.Count) {
+                for (int i = 0; i < expectedSensors.Count; i++) {
+                    Assert.Equal(expectedSensors[i].SiteId, vm.Sensors[i].SiteId);
+                }
+            }
+
+        }
+    }
+}

--- a/REA.Tests/ViewModels/MonitorSensorsViewModelTests.cs
+++ b/REA.Tests/ViewModels/MonitorSensorsViewModelTests.cs
@@ -27,12 +27,12 @@ namespace REA.Tests.ViewModels {
             // Assert NotNull (empty db records are still valid pass)
             Assert.NotNull(vm.Sensors);
 
+            Assert.Equal(expectedSensors.Count, vm.Sensors.Count);
+
             // Assert data structure
             Assert.Equal(expectedSensors.Count, vm.Sensors.Count);
-            if (expectedSensors != null && expectedSensors.Count > 0 && expectedSensors.Count == vm.Sensors.Count) {
-                for (int i = 0; i < expectedSensors.Count; i++) {
-                    Assert.Equal(expectedSensors[i].SiteId, vm.Sensors[i].SiteId);
-                }
+            for (int i = 0; i < expectedSensors.Count; i++) {
+                Assert.Equal(expectedSensors[i].SiteId, vm.Sensors[i].SiteId);
             }
 
         }

--- a/REA/ViewModels/MonitorSensorsViewModel.cs
+++ b/REA/ViewModels/MonitorSensorsViewModel.cs
@@ -17,15 +17,20 @@ namespace REA.ViewModels {
 
         // List of available sensors
         [ObservableProperty]
-        private ObservableCollection<Sensors> sensors;
+        public ObservableCollection<Sensors> sensors;
 
-        public MonitorSensorsViewModel() {
-            GetSensors();
+        // DB service
+        private readonly IDatabaseService _db;
+
+        public MonitorSensorsViewModel() : this(SQLiteDatabaseService.Instance) { }
+
+        public MonitorSensorsViewModel(IDatabaseService? db = null) {
+            _db = db ?? SQLiteDatabaseService.Instance;
         }
 
-        private async void GetSensors() {
+        public async Task GetSensors() {
             // Get all sensors from database
-            Sensors = new ObservableCollection<Sensors>(await SQLiteDatabaseService.Instance.GetItemsAsync<Sensors>());
+            Sensors = new ObservableCollection<Sensors>(await _db.GetItemsAsync<Sensors>());
         }
 
         // Set the selected sensor

--- a/REA/Views/MonitorSensorsPage.xaml
+++ b/REA/Views/MonitorSensorsPage.xaml
@@ -6,7 +6,7 @@
              Title="Monitor Sensors">
     
     <ContentPage.BindingContext>
-        <vm:MonitorSensorsViewModel />
+        <vm:MonitorSensorsViewModel x:Name="ViewModel" />
     </ContentPage.BindingContext>
 
     <VerticalStackLayout Padding="10" Spacing="10">

--- a/REA/Views/MonitorSensorsPage.xaml.cs
+++ b/REA/Views/MonitorSensorsPage.xaml.cs
@@ -2,11 +2,13 @@ using REA.ViewModels;
 
 namespace REA.Views;
 
-public partial class MonitorSensorsPage : ContentPage
-{
-	public MonitorSensorsPage()
-	{
+public partial class MonitorSensorsPage : ContentPage {
+	public MonitorSensorsPage() {
 		InitializeComponent();
-        BindingContext = new MonitorSensorsViewModel();
+    }
+
+    protected override async void OnAppearing() {
+        base.OnAppearing();
+        await ViewModel.GetSensors();
     }
 }


### PR DESCRIPTION
Added unit tests for `MonitorSensorsViewModel`.
- #66 

There's only one unit test which tests the retrieval of data and its integrity from the mocked database, but handles empty data scenarios as well.
Additionally, some refactoring has been done to lower the database service coupling with the ViewModel.